### PR TITLE
Cleaning up and shrinking the image, download from different source, …

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,28 +1,22 @@
-FROM ubuntu:14.04
+FROM debian:stretch-slim
 MAINTAINER Lewis
+
 ENV DEBIAN_FRONTEND noninteractive
+# this is the checksum of jdk-1_5_0_22-linux-amd64.bin from oracle
+ENV JDK_CSUM_SHA512 c181929619866470efa0cf8223d7349e2b703db41f8b16f25a8567ca44ee9a9817365cad0ea21ad9520cc08d2114234e1d9a2d23d777b9c532f830c0e1041e77
+ENV JAVA_HOME /jdk1.5.0_22
+ENV PATH /jdk1.5.0_22/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 RUN \
-    echo 'APT::Get::Assume-Yes "true";' > /etc/apt/apt.conf.d/90forceyes;\
-    echo 'deb http://archive.ubuntu.com/ubuntu trusty main universe restricted' > /etc/apt/sources.list;\
-    echo 'deb http://archive.ubuntu.com/ubuntu trusty-updates  main universe restricted' >> /etc/apt/sources.list;\
-    apt-get update;\
-    echo exit 101 > /usr/sbin/policy-rc.d && chmod +x /usr/sbin/policy-rc.d;\
-    dpkg-divert --local --rename --add /sbin/initctl;\
-    ln -sf /bin/true /sbin/initctl;\
-    apt-get -y upgrade && apt-get clean ;\
-    apt-get install gcc-multilib wget
-
-RUN \
-    cd /tmp ;\
-    wget --no-check-certificate --no-cookies --header "Cookie: oraclelicense=accept-securebackup-cookie" -O jdk-1_5_0_22-linux-amd64.bin http://download.oracle.com/otn-pub/java/jdk/1.5.0_22/jdk-1_5_0_22-linux-amd64.bin
+    apt-get update \
+    && apt-get -y install curl \
+    && curl http://monalisa.cern.ch/MONALISA/download/java/jdk-1_5_0_22-linux-amd64.bin > /tmp/jdk-1_5_0_22-linux-amd64.bin \
+    && echo "${JDK_CSUM_SHA512} /tmp/jdk-1_5_0_22-linux-amd64.bin" | sha512sum -c - \
+    && echo yes|sh /tmp/jdk-1_5_0_22-linux-amd64.bin \
+    && rm /tmp/jdk-1_5_0_22-linux-amd64.bin \
+    && apt-get -y purge curl \
+    && apt-get -y autoremove --purge \
+    && apt-get clean
 
 # alternate  java method disabled: download local jdk
 #ADD jdk-1_5_0_22-linux-amd64.bin /tmp/
-
-RUN \
-    echo yes|sh /tmp/jdk-1_5_0_22-linux-amd64.bin ;\
-    rm /tmp/jdk-1_5_0_22-linux-amd64.bin
-
-ENV JAVA_HOME /jdk1.5.0_22
-ENV PATH /jdk1.5.0_22/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin


### PR DESCRIPTION
- tested with Ubuntu 14.04, 16.04, 18.04, Debian Jessie and Stretch
- using debian:stretch-slim per default as it results in the smallest image, shrinking the image from 522MB to 186MB
- downloading the .bin from a different source as from oracle no automated downloads are possible anymore
- adding checksum-check since taking the file from a different source